### PR TITLE
Fix link to Library of Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Library Of Pybel
 ## About
-This is an open source python implementation of the [Library of Babel](libraryofbabel.info).
+This is an open source python implementation of the [Library of Babel](https://libraryofbabel.info).
 ## Functionality
 ### Javascript Implementation
 The Javascript implementation of the Library of Babel can be found [here](https://cakenggt.github.io/Library-Of-Pybel/). The text and addresses generated will not be the same between the Python implementation and this one. The source code for this JS implementation is hosted in the gh-pages branch. There is a search box and an address selector.


### PR DESCRIPTION
Fix the link to Library of Babel, actual link uses current location as base url.